### PR TITLE
Sync every 10 minutes

### DIFF
--- a/roles/reposync/tasks/main.yml
+++ b/roles/reposync/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: Add mirror run-parts cron entry
   cron:
     name: "sync mirrors"
-    hour: "*/4"
+    minute: "*/10"
     job: run-parts /var/mirror.d
 
 # xiph mirror


### PR DESCRIPTION
Previously, fosshost mirrors would sync every minute for a full hour every 4th hour: [link](https://crontab.guru/#*_*/4_*_*_*)
Since the fosshost mirrors are capable of handling syncing every minute for a whole hour, they are also capable of handling syncing every 10 minutes instead: [link](https://crontab.guru/#*/10_*_*_*_*)
Changing this behavior also makes the fosshost mirrors more viable as a repo mirror for fast-moving distros.