### PR TITLE
Add support for "owner" mirror parameter

### DIFF
--- a/roles/reposync/tasks/mirrors.yml
+++ b/roles/reposync/tasks/mirrors.yml
@@ -10,8 +10,10 @@ mirrors:
   source: rsync://apt.draugeros.org/downloadsync
 - name: garuda/repos
   source: rsync://builds.garudalinux.org/chaotic/
+  owner: garuda
 - name: garuda/iso
   source: rsync://iso.builds.garudalinux.org/iso/
+  owner: garuda
 - name: heptapod
   source: rsync://download.heptapod.net/fosshost-mirrored
 - name: ipfire

--- a/roles/reposync/templates/reposync.j2
+++ b/roles/reposync/templates/reposync.j2
@@ -6,7 +6,9 @@ LOCKFILE=/tmp/rsync-{{ item.name | regex_replace('\/', '_') }}.lock
 
 synchronize() {
     printf "starting sync for {{ item.name }}\n"
-    $RSYNC -rtlvH --delete-during --delay-updates --safe-links {{ item.source }} "$DESTPATH"
+    # Rsync's --chown does not set the owner of the directory itself
+    chown {{ item.owner | default('root') }} "$DESTPATH"
+    $RSYNC -rtlvoH --delete-during --delay-updates --safe-links --chown={{ item.owner | default('root') }} {{ item.source }} "$DESTPATH"
 }
 
 if [ ! -e "$LOCKFILE" ]


### PR DESCRIPTION
I can't test this, but this should work. I verified rsync takes these params like this, but if rsync on debian is too old it won't recognize --chown.